### PR TITLE
feat: integrated receiving products by id and products creation

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,11 +1,16 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { ProductItemComponent } from './products/product-item/product-item.component';
 import { ProductsComponent } from './products/products.component';
 
 const routes: Routes = [
   {
     path: '',
     component: ProductsComponent,
+  },
+  {
+    path: 'products/:id',
+    component: ProductItemComponent,
   },
   {
     path: 'cart',

--- a/src/app/products/product-item/product-item.component.html
+++ b/src/app/products/product-item/product-item.component.html
@@ -5,14 +5,15 @@
     </div>
   </div>
 
-  <header>
+  <header (click)="navigateToProduct()">
     <mat-card-title>
-      {{ product.title }}
+      {{ product?.title }}
     </mat-card-title>
   </header>
 
   <mat-card-content>
-    <p>{{ product.price | number: "1.2-2" | currency }}</p>
+    <p *ngIf="productIdParam">{{ product?.description }}</p>
+    <p>{{ product?.price | number: "1.2-2" | currency }}</p>
   </mat-card-content>
 
   <mat-card-actions>

--- a/src/app/products/product.interface.ts
+++ b/src/app/products/product.interface.ts
@@ -1,5 +1,4 @@
 export interface Product {
-  /** Available count */
   count: number;
   description: string;
   id: string;

--- a/src/app/products/products.service.ts
+++ b/src/app/products/products.service.ts
@@ -12,13 +12,6 @@ import { ApiService } from '../core/api.service';
 })
 export class ProductsService extends ApiService {
   createNewProduct(product: Product): Observable<Product> {
-    if (!this.endpointEnabled('bff')) {
-      console.warn(
-        'Endpoint "bff" is disabled. To enable change your environment.ts config'
-      );
-      return EMPTY;
-    }
-
     const url = this.getUrl('bff', 'products');
     return this.http.post<Product>(url, product);
   }
@@ -35,24 +28,9 @@ export class ProductsService extends ApiService {
     return this.http.put<Product>(url, changedProduct);
   }
 
-  getProductById(id: string): Observable<Product | null> {
-    if (!this.endpointEnabled('bff')) {
-      console.warn(
-        'Endpoint "bff" is disabled. To enable change your environment.ts config'
-      );
-      return this.http
-        .get<Product[]>('/assets/products.json')
-        .pipe(
-          map(
-            (products) => products.find((product) => product.id === id) || null
-          )
-        );
-    }
-
+  getProductById(id: string): Observable<Product> {
     const url = this.getUrl('bff', `products/${id}`);
-    return this.http
-      .get<{ product: Product }>(url)
-      .pipe(map((resp) => resp.product));
+    return this.http.get<Product>(url);
   }
 
   getProducts(): Observable<Product[]> {


### PR DESCRIPTION
Each product on the main page could be opened in a separate page either by clicking on card header or by direct url access.
example: https://d3rst5o72ocdj4.cloudfront.net/products/5a69aac3-a455-40a6-90fa-0b9fb51c01e9

Also creation of a new product is possible here https://d3rst5o72ocdj4.cloudfront.net/admin/products/new